### PR TITLE
feat(api): Implement get room availability #9

### DIFF
--- a/ISSUE_AVAILABLE_ROOMS.md
+++ b/ISSUE_AVAILABLE_ROOMS.md
@@ -1,0 +1,89 @@
+# Issue #2: [Feature] Get Available Rooms in Date Range
+
+## Description
+
+Implementasi endpoint untuk mendapatkan daftar ruangan yang tersedia (tidak ada booking atau conflict) dalam rentang tanggal tertentu. Endpoint ini berguna untuk user mencari ruangan yang bisa langsung di-book tanpa bentrok dengan peminjaman lain.
+
+**Use Case:**
+
+- User ingin booking ruangan untuk event tanggal 10-12 Maret, perlu tahu ruangan mana saja yang available
+- Admin ingin melihat overview ketersediaan semua ruangan dalam periode tertentu
+- Mempercepat proses pemilihan ruangan untuk booking baru
+
+## Proposed Solution
+
+**Endpoint:**
+
+```
+GET /api/ruangan/available?startDate={date}&endDate={date}
+```
+
+**Query Parameters:**
+
+- `startDate` (required): ISO 8601 date format (e.g., `2026-03-10T08:00:00`)
+- `endDate` (required): ISO 8601 date format (e.g., `2026-03-10T12:00:00`)
+
+**Response Structure:**
+
+```json
+{
+  "startDate": "2026-03-10T08:00:00Z",
+  "endDate": "2026-03-10T12:00:00Z",
+  "availableRooms": [
+    {
+      "id": 1,
+      "namaRuangan": "Ruang A101",
+      "lokasi": "Gedung A Lantai 1",
+      "kapasitas": 30
+    },
+    {
+      "id": 3,
+      "namaRuangan": "Ruang B201",
+      "lokasi": "Gedung B Lantai 2",
+      "kapasitas": 50
+    }
+  ],
+  "totalAvailable": 2,
+  "totalRooms": 10
+}
+```
+
+**Logic:**
+
+- Query semua ruangan
+- Untuk setiap ruangan, check apakah ada peminjaman yang overlap dengan range `[startDate, endDate]` dan `Status != "Rejected"`
+- Filter ruangan yang **tidak memiliki** overlap booking
+- Return list ruangan available dengan detail lengkap
+
+**Alternative Query (SQL-optimized):**
+
+```sql
+SELECT * FROM ruangan r
+WHERE r.id NOT IN (
+  SELECT DISTINCT ruangan_id FROM peminjaman
+  WHERE status != 'Rejected'
+    AND tanggal_pinjam < @endDate
+    AND tanggal_selesai > @startDate
+)
+```
+
+## Acceptance Criteria
+
+- [ ] Endpoint `GET /api/ruangan/available` tersedia
+- [ ] Query parameters `startDate` dan `endDate` required dan format valid
+- [ ] Validasi `endDate` > `startDate`, return 400 jika invalid
+- [ ] Return only ruangan yang **tidak memiliki conflict** dalam range tersebut
+- [ ] Ignore peminjaman dengan status "Rejected" dalam conflict check
+- [ ] Response include ruangan details (id, nama, lokasi, kapasitas)
+- [ ] Response include metadata: `totalAvailable`, `totalRooms`
+- [ ] Handle edge case: semua ruangan booked = empty array dengan `totalAvailable: 0`
+- [ ] Handle edge case: tidak ada peminjaman = semua ruangan available
+- [ ] Return 200 OK dengan list available rooms
+- [ ] Performance: query optimized untuk avoid N+1 problem
+
+## Technical Notes
+
+- Gunakan LINQ `Where()` dengan date range overlap logic: `TanggalPinjam < endDate && TanggalSelesai > startDate`
+- Consider timezone handling (semua DateTime harus UTC)
+- Add index pada `peminjaman(ruangan_id, tanggal_pinjam, tanggal_selesai)` untuk performance
+- Consider caching jika data availability sering di-query

--- a/ISSUE_ROOM_AVAILABILITY.md
+++ b/ISSUE_ROOM_AVAILABILITY.md
@@ -1,0 +1,75 @@
+# Issue #1: [Feature] Get Room Availability by Room ID
+
+## Description
+
+Implementasi endpoint untuk mengecek ketersediaan ruangan tertentu berdasarkan rentang tanggal. Endpoint ini akan mengembalikan daftar tanggal/periode waktu ketika ruangan tersebut sedang tidak dipinjam (available).
+
+**Use Case:**
+
+- User ingin melihat kapan saja Ruangan A tersedia dalam minggu/bulan tertentu
+- Admin ingin mengecek schedule booking ruangan tertentu
+- Membantu user menentukan waktu yang tepat untuk booking
+
+## Proposed Solution
+
+**Endpoint:**
+
+```
+GET /api/ruangan/:roomId/availability?startDate={date}&endDate={date}
+```
+
+**Query Parameters:**
+
+- `startDate` (required): ISO 8601 date format (e.g., `2026-03-01`)
+- `endDate` (required): ISO 8601 date format (e.g., `2026-03-31`)
+
+**Response Structure:**
+
+```json
+{
+  "ruanganId": 1,
+  "namaRuangan": "Ruang A101",
+  "startDate": "2026-03-01",
+  "endDate": "2026-03-31",
+  "bookedPeriods": [
+    {
+      "id": 5,
+      "namaPeminjam": "John Doe",
+      "tanggalPinjam": "2026-03-05T08:00:00Z",
+      "tanggalSelesai": "2026-03-05T10:00:00Z",
+      "status": "Approved"
+    }
+  ],
+  "availablePeriods": [
+    {
+      "start": "2026-03-01T00:00:00Z",
+      "end": "2026-03-05T08:00:00Z"
+    },
+    {
+      "start": "2026-03-05T10:00:00Z",
+      "end": "2026-03-31T23:59:59Z"
+    }
+  ]
+}
+```
+
+**Logic:**
+
+- Query peminjaman dengan `RuanganId = :roomId` dan `Status != "Rejected"`
+- Filter peminjaman yang overlap dengan range `[startDate, endDate]`
+- Sort by `TanggalPinjam`
+- Calculate gaps between bookings sebagai available periods
+
+## Acceptance Criteria
+
+- [ ] Endpoint `GET /api/ruangan/:roomId/availability` tersedia
+- [ ] Validasi `roomId` exists, return 404 jika tidak ditemukan
+- [ ] Validasi `startDate` dan `endDate` required dan format valid
+- [ ] Validasi `endDate` >= `startDate`, return 400 jika invalid
+- [ ] Return list of booked periods (exclude status "Rejected")
+- [ ] Return list of available periods (gaps between bookings)
+- [ ] Response include metadata ruangan (id, nama)
+- [ ] Booked periods sorted by tanggal pinjam ascending
+- [ ] Handle edge case: no bookings = entire period available
+- [ ] Handle edge case: fully booked = empty availablePeriods array
+- [ ] Return 200 OK dengan data availability

--- a/PeminjamanRuangan.Api/Controllers/RuanganController.cs
+++ b/PeminjamanRuangan.Api/Controllers/RuanganController.cs
@@ -134,4 +134,77 @@ public class RuanganController : ControllerBase
         
         return NoContent();
     }
+
+    // GET /api/ruangan/{id}/availability?startDate={date}&endDate={date}
+    [HttpGet("{id:int}/availability")]
+    public async Task<IActionResult> GetAvailability(
+        int id,
+        [FromQuery] DateTime? startDate,
+        [FromQuery] DateTime? endDate)
+    {
+        // Validate ruangan exists
+        var ruangan = await _db.Ruangan.FindAsync(id);
+        if (ruangan is null)
+            return NotFound(new { message = "Ruangan tidak ditemukan" });
+
+        // Validate query parameters
+        if (!startDate.HasValue || !endDate.HasValue)
+            return BadRequest(new { message = "Parameter startDate dan endDate wajib diisi" });
+
+        if (endDate.Value < startDate.Value)
+            return BadRequest(new { message = "endDate harus >= startDate" });
+
+        // Query booked periods (exclude Rejected status)
+        var bookedPeriods = await _db.Peminjaman
+            .AsNoTracking()
+            .Where(p => p.RuanganId == id
+                && p.Status != "Rejected"
+                && p.TanggalPinjam < endDate.Value
+                && p.TanggalSelesai > startDate.Value)
+            .OrderBy(p => p.TanggalPinjam)
+            .Select(p => new BookedPeriod(
+                p.Id,
+                p.NamaPeminjam,
+                p.TanggalPinjam,
+                p.TanggalSelesai,
+                p.Status
+            ))
+            .ToListAsync();
+
+        // Calculate available periods (gaps between bookings)
+        var availablePeriods = new List<AvailablePeriod>();
+        var currentStart = startDate.Value;
+
+        foreach (var booked in bookedPeriods)
+        {
+            // If there's a gap before this booking
+            if (currentStart < booked.TanggalPinjam)
+            {
+                availablePeriods.Add(new AvailablePeriod(currentStart, booked.TanggalPinjam));
+            }
+            
+            // Move current pointer to end of this booking
+            if (booked.TanggalSelesai > currentStart)
+            {
+                currentStart = booked.TanggalSelesai;
+            }
+        }
+
+        // Add final period if there's time left after last booking
+        if (currentStart < endDate.Value)
+        {
+            availablePeriods.Add(new AvailablePeriod(currentStart, endDate.Value));
+        }
+
+        var response = new RuanganAvailabilityResponse(
+            ruangan.Id,
+            ruangan.NamaRuangan,
+            startDate.Value,
+            endDate.Value,
+            bookedPeriods.ToList(),
+            availablePeriods
+        );
+
+        return Ok(response);
+    }
 }

--- a/PeminjamanRuangan.Api/DTOs/RuanganDto.cs
+++ b/PeminjamanRuangan.Api/DTOs/RuanganDto.cs
@@ -20,3 +20,25 @@ public record RuanganResponse(
     DateTime CreatedAt,
     DateTime UpdatedAt
 );
+
+public record BookedPeriod(
+    int Id,
+    string NamaPeminjam,
+    DateTime TanggalPinjam,
+    DateTime TanggalSelesai,
+    string Status
+);
+
+public record AvailablePeriod(
+    DateTime Start,
+    DateTime End
+);
+
+public record RuanganAvailabilityResponse(
+    int RuanganId,
+    string NamaRuangan,
+    DateTime StartDate,
+    DateTime EndDate,
+    List<BookedPeriod> BookedPeriods,
+    List<AvailablePeriod> AvailablePeriods
+);


### PR DESCRIPTION
## PR: Room Availability Endpoint

### Description
Add endpoint to fetch availability for a specific room within a date range.

### Changes
- New DTOs for booked and available periods
- New endpoint: `GET /api/ruangan/{id}/availability`
- Validations: room exists, date range required and valid
- Calculates available gaps between bookings (excluding `Rejected`)
- Insomnia collection updated with sample request

### Testing
- `GET /api/ruangan/1/availability?startDate=2026-03-01&endDate=2026-03-31` → 200 OK
- Invalid dates → 400
- Room not found → 404

### Related Issues
Closes #9 