### PR TITLE
Feature/api documentation

### DIFF
--- a/PeminjamanRuangan.Api/PeminjamanRuangan.Api.csproj
+++ b/PeminjamanRuangan.Api/PeminjamanRuangan.Api.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.12.37" />
   </ItemGroup>
 
 </Project>

--- a/PeminjamanRuangan.Api/PeminjamanRuangan.Api.csproj
+++ b/PeminjamanRuangan.Api/PeminjamanRuangan.Api.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
   </ItemGroup>
 
 </Project>

--- a/PeminjamanRuangan.Api/Program.cs
+++ b/PeminjamanRuangan.Api/Program.cs
@@ -8,7 +8,18 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllers();
-builder.Services.AddOpenApi();
+builder.Services.AddOpenApi("v1", options =>
+{
+    options.AddDocumentTransformer((document, _, _) =>
+    {
+        document.Info.Title = "Peminjaman Ruangan API";
+        document.Info.Version = "v1";
+        document.Info.Description = "API untuk manajemen ruangan dan peminjaman.";
+        return Task.CompletedTask;
+    });
+});
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 // Configure PostgreSQL Database
 builder.Services.AddDbContext<AppDbContext>(options =>
@@ -27,7 +38,13 @@ using (var scope = app.Services.CreateScope())
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
+    app.MapOpenApi("/openapi/{documentName}.json");
+    app.UseSwagger();
+    app.UseSwaggerUI(options =>
+    {
+        options.SwaggerEndpoint("/swagger/v1/swagger.json", "Peminjaman Ruangan API v1");
+        options.RoutePrefix = "swagger";
+    });
 }
 
 app.UseHttpsRedirection();

--- a/PeminjamanRuangan.Api/Program.cs
+++ b/PeminjamanRuangan.Api/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PeminjamanRuangan.Api.Data;
+using Scalar.AspNetCore;
 
 // Allow DateTime with any Kind to be sent to PostgreSQL (treats Unspecified as UTC)
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
@@ -19,7 +20,6 @@ builder.Services.AddOpenApi("v1", options =>
     });
 });
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 
 // Configure PostgreSQL Database
 builder.Services.AddDbContext<AppDbContext>(options =>
@@ -39,11 +39,9 @@ using (var scope = app.Services.CreateScope())
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi("/openapi/{documentName}.json");
-    app.UseSwagger();
-    app.UseSwaggerUI(options =>
+    app.MapScalarApiReference(options => 
     {
-        options.SwaggerEndpoint("/swagger/v1/swagger.json", "Peminjaman Ruangan API v1");
-        options.RoutePrefix = "swagger";
+        options.OpenApiRoutePattern = "/openapi/v1.json";
     });
 }
 


### PR DESCRIPTION
## Description
Add OpenAPI documentation and interactive Scalar UI for the Peminjaman Ruangan API.

## Changes
- **OpenAPI Integration**: Added Microsoft.AspNetCore.OpenApi support with v1 document configuration
  - OpenAPI specification available at `/openapi/v1.json`
  - Document metadata includes title, version, and description
  
- **Scalar UI**: Added interactive API documentation interface powered by Scalar.AspNetCore
  - Accessible at root path (`/`) in development environment
  - Allows browsing and testing all API endpoints directly in the browser
  - Modern, mobile-friendly interface

- **Dependencies**: Leveraging native .NET 10 OpenAPI support instead of Swashbuckle

## Environment
- Development: OpenAPI spec and Scalar UI enabled
- Production: OpenAPI disabled (can be re-enabled if needed)

## Testing
- All endpoints are testable through Scalar UI at `http://localhost:5000/scalar/v1`
- No changes to existing API logic or business rules

## Related Issues
Closes #13 